### PR TITLE
Provide UUIDs for reflected files

### DIFF
--- a/Products/Reflecto/configure.zcml
+++ b/Products/Reflecto/configure.zcml
@@ -31,13 +31,19 @@
 <five:deprecatedManageAddDelete
     class=".content.reflector.Reflector" />
 
-
-
 <adapter
     zcml:condition="installed Products.TextIndexNG3"
     factory=".catalog.FileProxyIndexableContentAdapter"
     />
 
 <include file="events.zcml" />
+
+<configure
+    zcml:condition="installed plone.app.uuid">
+  <class class=".content.proxy.BaseProxy">
+    <implements interface="plone.uuid.interfaces.IUUIDAware" />
+  </class>
+  <adapter factory=".uuids.reflectoUUID" />
+</configure>
 
 </configure>

--- a/Products/Reflecto/tests/testUuids.py
+++ b/Products/Reflecto/tests/testUuids.py
@@ -1,0 +1,20 @@
+import unittest
+from Products.Reflecto.tests.utils import MockReflector
+
+
+class UUIDTests(unittest.TestCase):
+
+    def setUp(self):
+        self.reflector = MockReflector()
+
+    def testReflectorUUID(self):
+        from Products.Reflecto.uuids import reflectoUUID
+        uid = reflectoUUID(self.reflector)
+        self.assertEqual(uid, self.reflector._at_uid)
+
+    def testProxyUUID(self):
+        from Products.Reflecto.uuids import reflectoUUID
+        from Products.Reflecto.content.file import ReflectoFile
+        proxy = ReflectoFile(("reflecto.txt",)).__of__(self.reflector)
+        uid = reflectoUUID(proxy)
+        self.assertFalse(uid == self.reflector._at_uid)

--- a/Products/Reflecto/tests/utils.py
+++ b/Products/Reflecto/tests/utils.py
@@ -11,6 +11,7 @@ samplesPath=os.path.join(sys.modules["Products.Reflecto.tests"].__path__[0],
 class MockReflector(Acquisition.Implicit):
     implements(IReflector)
 
+    _at_uid = '35b46994-7454-4efa-8888-54c9b068230b'
+
     def getFilesystemPath(self):
         return samplesPath
-

--- a/Products/Reflecto/uuids.py
+++ b/Products/Reflecto/uuids.py
@@ -1,0 +1,27 @@
+from Products.Reflecto.interfaces import IReflectoProxy
+from Products.Reflecto.interfaces import IReflector
+from Products.Reflecto.utils import makePathAbsolute
+from hashlib import md5
+from plone.uuid.interfaces import IUUID
+from uuid import UUID
+from zope.component import adapter
+from zope.interface import implementer
+import os.path
+
+
+@implementer(IUUID)
+@adapter(IReflectoProxy)
+def reflectoUUID(context):
+    # Short-circuit for top level.
+    # We have to get the UID directly to avoid recursing
+    if IReflector.providedBy(context):
+        return context._at_uid
+
+    # Return a UUID based on the filesystem path
+    path = os.path.join(
+        makePathAbsolute(
+            context.getReflector().relativePath
+        ),
+        *context.getPathToReflectoParent()
+    )
+    return str(UUID(bytes=md5('Reflecto' + path).digest()))

--- a/Products/Reflecto/uuids.py
+++ b/Products/Reflecto/uuids.py
@@ -1,6 +1,5 @@
 from Products.Reflecto.interfaces import IReflectoProxy
 from Products.Reflecto.interfaces import IReflector
-from Products.Reflecto.utils import makePathAbsolute
 from hashlib import md5
 from plone.uuid.interfaces import IUUID
 from uuid import UUID
@@ -18,10 +17,6 @@ def reflectoUUID(context):
         return context._at_uid
 
     # Return a UUID based on the filesystem path
-    path = os.path.join(
-        makePathAbsolute(
-            context.getReflector().relativePath
-        ),
-        *context.getPathToReflectoParent()
-    )
-    return str(UUID(bytes=md5('Reflecto' + path).digest()))
+    path = os.path.join(*context.getPathToReflectoParent())
+    reflector_uid = context.getReflector()._at_uid
+    return str(UUID(bytes=md5(reflector_uid + path).digest()))

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 3.0b2 - Unreleased
 ------------------------
 
-- ...
+- If plone.app.uuid is present, provide a UUID for reflected files.
+  The UUID is based on the main reflector's UID and the file's path.
+  [davisagli]
 
 
 3.0b1 - January 23, 2013


### PR DESCRIPTION
UIDs are needed for some integrations (such as with collective.solr). This provides a stable UID based on the UID of the main Reflector and the relative path of the file.
