### PR TITLE
Fix chrome duplicated header

### DIFF
--- a/Products/Reflecto/browser/download.py
+++ b/Products/Reflecto/browser/download.py
@@ -11,7 +11,7 @@ class FileDownloadView(BrowserView):
     def __call__(self):
         self.request.response.setHeader(
             'Content-Disposition',
-            'attachment; filename=%s' % self.context.getId())
+            'attachment; filename="%s"' % self.context.getId())
         return self.context()
 
 

--- a/Products/Reflecto/content/file.py
+++ b/Products/Reflecto/content/file.py
@@ -160,7 +160,7 @@ class ReflectoFile(BaseMove, Resource, BaseProxy, DynamicType):
                               for info in icc.getFieldData('SearchableText'))
         elif self.Format().startswith("text/"):
             data = self.get_data()
-            encoding = chardet.detect(data)["encoding"]
+            encoding = chardet.detect(data)["encoding"] or 'ascii'
             result += ' ' + data.decode(encoding, 'ignore').encode('utf8')
 
         return result

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.0.6 - unreleased
 ------------------
 
+- Fixed an issue with some files that do not return any encoding.
+  Let's fallback to ASCII.
+  [keul]
 
 3.0.5 - July 11, 2013
 ---------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,11 @@ Changelog
   Let's fallback to ASCII.
   [keul]
 
+- Quoting filename in ``Content-Disposition`` header to prevent
+  ``ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION`` problem
+  with Chrome browser.
+  [keul]
+
 3.0.5 - July 11, 2013
 ---------------------
 


### PR DESCRIPTION
A couple of fixes.

The main one only affect Chrome browser with some filenames. If you have a filename with some spaces and a comma inside you'll get the `ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION` error

The other problem came with some files, where calling `chardet.detect(data)` returns `{'confidence': 0.0, 'encoding': None}`. This will raise an exception.
