### PR TITLE
don't try to decode textual content when no encoding could be determined

### DIFF
--- a/Products/Reflecto/content/file.py
+++ b/Products/Reflecto/content/file.py
@@ -161,7 +161,9 @@ class ReflectoFile(BaseMove, Resource, BaseProxy, DynamicType):
         elif self.Format().startswith("text/"):
             data = self.get_data()
             encoding = chardet.detect(data)["encoding"]
-            result += ' ' + data.decode(encoding, 'ignore').encode('utf8')
+            if encoding is not None:
+                data = data.decode(encoding, 'ignore')
+            result += ' ' + data.encode('utf8')
 
         return result
     

--- a/Products/Reflecto/tests/testCatalog.py
+++ b/Products/Reflecto/tests/testCatalog.py
@@ -27,12 +27,15 @@ class IndexTests(unittest.TestCase):
     def setUp(self):
         self.reflector = MockReflector()
 
-
     def testTextualSearchableText(self):
         proxy=ReflectoFile(("reflecto.txt",)).__of__(self.reflector)
         self.failUnless("superhero" in proxy.SearchableText())
         self.failUnless("reflecto.txt" in proxy.SearchableText())
 
+    def testEmptyTextualSearchableText(self):
+        proxy=ReflectoFile(("subdir/emptyfile.txt",)).__of__(self.reflector)
+        self.failUnless("superhero" in proxy.SearchableText())
+        self.failUnless("reflecto.txt" in proxy.SearchableText())
 
     def testBinarySearchableText(self):
         proxy=ReflectoFile(("reflecto.jpg",)).__of__(self.reflector)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 3.0.6 - unreleased
 ------------------
 
+- Don't try to decode textual content when no encoding could be determined.
+  [witsch]
 
 3.0.5 - July 11, 2013
 ---------------------


### PR DESCRIPTION
this happens for empty files, for example
